### PR TITLE
Clean client jar

### DIFF
--- a/grails-vaadin7-plugin/scripts/_Events.groovy
+++ b/grails-vaadin7-plugin/scripts/_Events.groovy
@@ -7,8 +7,12 @@ eventWarStart = { warName ->
 
 eventCreateWarStart = { name, stagingDir ->
 
+	// Allow override's in Config.groovy
+	boolean removeClientJar = config?.grails?.vaadin?.removeClientJar ?: true
+	
 	// Remove the vaadin-client jar from the web archive to reduce the size, this jar is only needed for client dev and
-	// not in the war archive, the files size is 15 mb
-	ant.delete(dir:"${stagingDir}/WEB-INF/lib/", includes: "vaadin-client-7.*.*.jar", verbose: true)
+	// not in the war carchive, the files size is 15 mb
+	if(removeClientJar) 
+		ant.delete(dir:"${stagingDir}/WEB-INF/lib/", includes: "vaadin-client-7.*.*.jar", verbose: true)
 	
 }


### PR DESCRIPTION
Hi, 
As discussed the vaadin-client-_._.*.jar is a 16mb file that should not be included in the final war, I've added functionality to exclude this file as well as a config property to toggle behaviour.

Best Regards
Marko
