### PR TITLE
compiling the sass themes should not be a matter of production env but of the configured "productionMode" of the environment

### DIFF
--- a/grails-vaadin7-plugin/scripts/_Events.groovy
+++ b/grails-vaadin7-plugin/scripts/_Events.groovy
@@ -18,8 +18,8 @@ eventCreateWarStart = { name, stagingDir ->
         sassCompile = '7.1.9'
     }
 
-    if (Environment.PRODUCTION == Environment.current) {
-        // compile SCSS when running 'grails prod war'
+    if (config?.productionMode) {
+        // compile SCSS when in production mode... aka Vaadin does no on-the-fly-compilation
         ant.echo('SASS compilation: Starting')
         ant.echo("SASS compilation: Themes for compilation: ${config?.themes}")
         if (config?.themes instanceof List) {


### PR DESCRIPTION
to my understanding setting the productionMode of vaadin for grails production environment is a default/convention/best practice (which i also follow).  But there might be other grails environments, that do also have productionMode of vaadin set (staging environments e.g.)
