### PR TITLE
remove the vaadin-client-compiler jar from the generated war

### DIFF
--- a/grails-vaadin7-plugin/scripts/_Events.groovy
+++ b/grails-vaadin7-plugin/scripts/_Events.groovy
@@ -74,6 +74,9 @@ eventCreateWarStart = { name, stagingDir ->
         ant.delete(dir: "${stagingDir}/WEB-INF/lib/", includes: "vaadin-client-7.*.*.jar", verbose: true)
     }
 
+    // remove the client compiler in any case
+    ant.delete(dir:"${stagingDir}/WEB-INF/lib/", includes: "vaadin-client-compiler-7.*.*.jar", verbose: true)
+
     GantState.verbosity = GantState.WARNINGS_AND_ERRORS
     ant.logger.setMessageOutputLevel(GantState.verbosity)
 }


### PR DESCRIPTION
this jar is definetly only used to compile widgetsets
