### PR TITLE
Added support for custom init-param in VaadinConfig

### DIFF
--- a/grails-vaadin7-plugin/VaadinGrailsPlugin.groovy
+++ b/grails-vaadin7-plugin/VaadinGrailsPlugin.groovy
@@ -80,7 +80,7 @@ class VaadinGrailsPlugin {
                             "param-value"(widgetset)
                         }
                     }
-                    for(def name : initParams.keySet()){
+                    for (def name : initParams?.keySet()) {
                         "init-param" {
                             "param-name"(name)
                             "param-value"(initParams.get(name))


### PR DESCRIPTION
With this modification one will be able to set one or more custom init-param directly in VaadinConfig like the following:

```
vaadin {
..............
    initParams = [
        "param-name-1":"param-value-1"
    ]
..............
}
```

This is useful for example if you are using vaadin-push with spring-security and you have to set an init-value for the init-param AtmosphereInterceptor.
