### PR TITLE
Load message source by name instead of class.

### DIFF
--- a/grails-vaadin7-plugin/src/groovy/com/vaadin/grails/Grails.groovy
+++ b/grails-vaadin7-plugin/src/groovy/com/vaadin/grails/Grails.groovy
@@ -49,7 +49,7 @@ class Grails {
      */
     public static MessageSource getMessageSource() {
         ApplicationContext context = getApplicationContext()
-        MessageSource res = context.getBean(MessageSource)
+        MessageSource res = context.getBean('messageSource')
         return res
     }
 


### PR DESCRIPTION
Necessary to override the MessageSource.
