### PR TITLE
use plugin dir as source for quickstart templates

### DIFF
--- a/grails-vaadin7-plugin/scripts/VaadinQuickstart.groovy
+++ b/grails-vaadin7-plugin/scripts/VaadinQuickstart.groovy
@@ -3,24 +3,14 @@ import grails.util.BuildSettingsHolder
 includeTargets << grailsScript("_GrailsInit")
 
 target(vaadinQuickstart: "Generates MyUI class and removed UrlMapping to easier project startup.") {
-
-    // Get Vaadin plugin base dir to look for templates
-    String pluginBasedir
-    BuildSettingsHolder.settings.pluginDirectories.each { File dir ->
-        String path = dir.absolutePath
-        if (path.split(File.separator).last().contains('vaadin')) {
-            pluginBasedir = path
-        }
-    }
-
     // Create MyUI sample class
     ant.mkdir(dir: "${basedir}/src/groovy/app")
-    ant.copy(file: "${pluginBasedir}/src/samples/_MyUI.template",
+    ant.copy(file: "${vaadinPluginDir}/src/samples/_MyUI.template",
             tofile: "${basedir}/src/groovy/app/MyUI.groovy")
 
     // Replace existing UrlMappings with empty one
     ant.delete(file: "${basedir}/grails-app/conf/UrlMappings.groovy")
-    ant.copy(file: "${pluginBasedir}/src/samples/_UrlMappings.template",
+    ant.copy(file: "${vaadinPluginDir}/src/samples/_UrlMappings.template",
             tofile: "${basedir}/grails-app/conf/UrlMappings.groovy")
 }
 


### PR DESCRIPTION
There is no need to search for the plugin's root dir, there is a var set from
grails for it.  Current code fails to run on windows, as the `\` file separator
would need quoting.